### PR TITLE
Fix RCE/LFI in vulnerabilities/view_help.php (remove eval, validate paths)

### DIFF
--- a/vulnerabilities/view_help.php
+++ b/vulnerabilities/view_help.php
@@ -8,23 +8,47 @@ dvwaPageStartup( array( 'authenticated' ) );
 $page = dvwaPageNewGrab();
 $page[ 'title' ] = 'Help' . $page[ 'title_separator' ].$page[ 'title' ];
 
-if (array_key_exists ("id", $_GET) &&
-	array_key_exists ("security", $_GET) &&
-	array_key_exists ("locale", $_GET)) {
+$help = "<p>Not Found</p>";
+
+if (
+	array_key_exists( 'id', $_GET ) &&
+	array_key_exists( 'security', $_GET ) &&
+	array_key_exists( 'locale', $_GET )
+) {
 	$id       = $_GET[ 'id' ];
 	$security = $_GET[ 'security' ];
-	$locale = $_GET[ 'locale' ];
+	$locale   = $_GET[ 'locale' ];
 
-	ob_start();
-	if ($locale == 'en') {
-		eval( '?>' . file_get_contents( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/help/help.php" ) . '<?php ' );
-	} else {
-		eval( '?>' . file_get_contents( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/help/help.{$locale}.php" ) . '<?php ' );
+	// Strict allowlists to prevent path traversal / arbitrary file read
+	$allowed_security = array( 'low', 'medium', 'high', 'impossible' );
+	if( !in_array( $security, $allowed_security, true ) ) {
+		$security = 'impossible';
 	}
-	$help = ob_get_contents();
-	ob_end_clean();
-} else {
-	$help = "<p>Not Found</p>";
+
+	if( preg_match( '/^[a-z0-9_]+$/', $id ) === 1 ) {
+		$baseHelpDir = realpath( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/help" );
+		$baseVulnDir = realpath( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}" );
+
+		// Ensure the directory exists and is within the intended vulnerabilities directory
+		if( $baseHelpDir !== false && $baseVulnDir !== false && strpos( $baseHelpDir, $baseVulnDir ) === 0 ) {
+			// Locale allowlist: 2-5 letters/dashes only (e.g. en, zh, pt-BR)
+			if( preg_match( '/^[a-z]{2,5}(-[A-Z]{2})?$/', $locale ) !== 1 ) {
+				$locale = 'en';
+			}
+
+			$helpFile = ($locale === 'en')
+				? ( $baseHelpDir . DIRECTORY_SEPARATOR . 'help.php' )
+				: ( $baseHelpDir . DIRECTORY_SEPARATOR . "help.{$locale}.php" );
+
+			$resolved = realpath( $helpFile );
+			if( $resolved !== false && strpos( $resolved, $baseHelpDir ) === 0 && is_file( $resolved ) ) {
+				ob_start();
+				include $resolved;
+				$help = ob_get_contents();
+				ob_end_clean();
+			}
+		}
+	}
 }
 
 $page[ 'body' ] .= "


### PR DESCRIPTION
Closes #38.

Changes:
- Remove `eval()` usage when rendering help pages.
- Add strict allowlisting and `realpath()` prefix checks to prevent path traversal/arbitrary file read.
- Use safe `include` with output buffering.

Security impact:
- Prevents path traversal to unintended files.
- Removes eval-based code execution primitive.
