### PR TITLE
Fix path traversal in source viewers (view_source.php, view_source_all.php)

### DIFF
--- a/vulnerabilities/view_source.php
+++ b/vulnerabilities/view_source.php
@@ -8,12 +8,23 @@ dvwaPageStartup( array( 'authenticated' ) );
 $page = dvwaPageNewGrab();
 $page[ 'title' ] .= 'Source' . $page[ 'title_separator' ].$page[ 'title' ];
 
-if (array_key_exists ("id", $_GET) && array_key_exists ("security", $_GET)) {
+if( array_key_exists( 'id', $_GET ) && array_key_exists( 'security', $_GET ) ) {
 	$id       = $_GET[ 'id' ];
 	$security = $_GET[ 'security' ];
 
+	// Validate inputs to prevent traversal/arbitrary file read
+	$allowed_security = array( 'low', 'medium', 'high', 'impossible' );
+	if( !in_array( $security, $allowed_security, true ) ) {
+		$security = 'impossible';
+	}
 
-	switch ($id) {
+	if( preg_match( '/^[a-z0-9_]+$/', $id ) !== 1 ) {
+		$page['body'] = "<p>Not found</p>";
+		dvwaSourceHtmlEcho( $page );
+		exit;
+	}
+
+	switch( $id ) {
 		case "fi" :
 			$vuln = 'File Inclusion';
 			break;
@@ -60,12 +71,26 @@ if (array_key_exists ("id", $_GET) && array_key_exists ("security", $_GET)) {
 			$vuln = "Unknown Vulnerability";
 	}
 
-	$source = @file_get_contents( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/source/{$security}.php" );
+	$baseDir = realpath( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/source" );
+	if( $baseDir === false ) {
+		$page['body'] = "<p>Not found</p>";
+		dvwaSourceHtmlEcho( $page );
+		exit;
+	}
+
+	$phpCandidate = $baseDir . DIRECTORY_SEPARATOR . "{$security}.php";
+	$phpResolved  = realpath( $phpCandidate );
+	$source       = '';
+	if( $phpResolved !== false && strpos( $phpResolved, $baseDir ) === 0 && is_file( $phpResolved ) ) {
+		$source = @file_get_contents( $phpResolved );
+	}
 	$source = str_replace( array( '$html .=' ), array( 'echo' ), $source );
 
 	$js_html = "";
-	if (file_exists (DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/source/{$security}.js")) {
-		$js_source = @file_get_contents( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/source/{$security}.js" );
+	$jsCandidate = $baseDir . DIRECTORY_SEPARATOR . "{$security}.js";
+	$jsResolved  = realpath( $jsCandidate );
+	if( $jsResolved !== false && strpos( $jsResolved, $baseDir ) === 0 && is_file( $jsResolved ) ) {
+		$js_source = @file_get_contents( $jsResolved );
 		$js_html = "
 		<h2>vulnerabilities/{$id}/source/{$security}.js</h2>
 		<div id=\"code\">
@@ -97,7 +122,8 @@ if (array_key_exists ("id", $_GET) && array_key_exists ("security", $_GET)) {
 			<input type=\"button\" value=\"Compare All Levels\" onclick=\"window.location.href='view_source_all.php?id=$id'\">
 		</form>
 	</div>\n";
-} else {
+}
+else {
 	$page['body'] = "<p>Not found</p>";
 }
 

--- a/vulnerabilities/view_source_all.php
+++ b/vulnerabilities/view_source_all.php
@@ -8,24 +8,47 @@ dvwaPageStartup(array('authenticated'));
 $page = dvwaPageNewGrab();
 $page['title'] = 'Source' . $page['title_separator'] . $page['title'];
 
-if (array_key_exists("id", $_GET)) {
+if( array_key_exists( 'id', $_GET ) ) {
 	$id = $_GET['id'];
 
-	$lowsrc = @file_get_contents("./{$id}/source/low.php");
-	$lowsrc = str_replace(array('$html .='), array('echo'), $lowsrc);
-	$lowsrc = highlight_string($lowsrc, true);
+	// Prevent traversal/arbitrary file reads
+	if( preg_match( '/^[a-z0-9_]+$/', $id ) !== 1 ) {
+		$page['body'] = "<p>Not found</p>";
+		dvwaSourceHtmlEcho($page);
+		exit;
+	}
 
-	$medsrc = @file_get_contents("./{$id}/source/medium.php");
-	$medsrc = str_replace(array('$html .='), array('echo'), $medsrc);
-	$medsrc = highlight_string($medsrc, true);
+	$baseDir = realpath( __DIR__ . DIRECTORY_SEPARATOR . $id . DIRECTORY_SEPARATOR . 'source' );
+	if( $baseDir === false ) {
+		$page['body'] = "<p>Not found</p>";
+		dvwaSourceHtmlEcho($page);
+		exit;
+	}
 
-	$highsrc = @file_get_contents("./{$id}/source/high.php");
+	function dvwa_safe_read_source( $baseDir, $filename ) {
+		$candidate = $baseDir . DIRECTORY_SEPARATOR . $filename;
+		$resolved  = realpath( $candidate );
+		if( $resolved === false || strpos( $resolved, $baseDir ) !== 0 || !is_file( $resolved ) ) {
+			return '';
+		}
+		return @file_get_contents( $resolved );
+	}
+
+	$lowsrc  = dvwa_safe_read_source( $baseDir, 'low.php' );
+	$lowsrc  = str_replace(array('$html .='), array('echo'), $lowsrc);
+	$lowsrc  = highlight_string($lowsrc, true);
+
+	$medsrc  = dvwa_safe_read_source( $baseDir, 'medium.php' );
+	$medsrc  = str_replace(array('$html .='), array('echo'), $medsrc);
+	$medsrc  = highlight_string($medsrc, true);
+
+	$highsrc = dvwa_safe_read_source( $baseDir, 'high.php' );
 	$highsrc = str_replace(array('$html .='), array('echo'), $highsrc);
 	$highsrc = highlight_string($highsrc, true);
 
-	$impsrc = @file_get_contents("./{$id}/source/impossible.php");
-	$impsrc = str_replace(array('$html .='), array('echo'), $impsrc);
-	$impsrc = highlight_string($impsrc, true);
+	$impsrc  = dvwa_safe_read_source( $baseDir, 'impossible.php' );
+	$impsrc  = str_replace(array('$html .='), array('echo'), $impsrc);
+	$impsrc  = highlight_string($impsrc, true);
 
 	switch ($id) {
 		case "javascript":
@@ -116,7 +139,8 @@ if (array_key_exists("id", $_GET)) {
 		</form>
 
 	</div>\n";
-} else {
+}
+else {
 	$page['body'] = "<p>Not found</p>";
 }
 


### PR DESCRIPTION
Closes #36.

Changes:
- Validate `id` and `security` params with allowlists.
- Use `realpath()` + prefix checks to ensure resolved file paths remain within the intended `vulnerabilities/<id>/source` directory.
- Fail closed when invalid.

Security impact:
- Prevents arbitrary local file read via path traversal.
