### PR TITLE
Restrict phpinfo.php to admin users only

### DIFF
--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -320,7 +320,10 @@ function dvwaHtmlEcho( $pPage ) {
 	$menuBlocks[ 'meta' ] = array();
 	if( dvwaIsLoggedIn() ) {
 		$menuBlocks[ 'meta' ][] = array( 'id' => 'security', 'name' => 'DVWA Security', 'url' => 'security.php' );
-		$menuBlocks[ 'meta' ][] = array( 'id' => 'phpinfo', 'name' => 'PHP Info', 'url' => 'phpinfo.php' );
+		// Only show PHP Info to admin users
+		if( dvwaCurrentUser() == 'admin' ) {
+			$menuBlocks[ 'meta' ][] = array( 'id' => 'phpinfo', 'name' => 'PHP Info', 'url' => 'phpinfo.php' );
+		}
 	}
 	$menuBlocks[ 'meta' ][] = array( 'id' => 'about', 'name' => 'About', 'url' => 'about.php' );
 

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -5,6 +5,12 @@ require_once DVWA_WEB_PAGE_TO_ROOT . 'dvwa/includes/dvwaPage.inc.php';
 
 dvwaPageStartup( array( 'authenticated') );
 
+// Limit phpinfo() exposure to admin only
+if( dvwaCurrentUser() !== 'admin' ) {
+	header( 'HTTP/1.1 403 Forbidden' );
+	die( 'Forbidden' );
+}
+
 phpinfo();
 
 ?>


### PR DESCRIPTION
Closes #37.

Changes:
- Enforce `403 Forbidden` for non-admin users on `phpinfo.php`.
- Hide the PHP Info menu entry from non-admin users.

Security impact:
- Reduces sensitive environment disclosure to low-privileged authenticated users.
