### PR TITLE
Restrict permissive CORS on API endpoints via origin allowlist

### DIFF
--- a/vulnerabilities/api/gen_openapi.php
+++ b/vulnerabilities/api/gen_openapi.php
@@ -3,10 +3,26 @@ require("vendor/autoload.php");
 
 $openapi = \OpenApi\Generator::scan(['./src']);
 
-header("Access-Control-Allow-Origin: *");
+function dvwa_api_set_cors_headers(): void {
+	$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+	$allowlist = getenv('DVWA_API_CORS_ALLOW_ORIGINS');
+
+	// Default deny unless explicitly allowlisted.
+	if ($allowlist !== false && $allowlist !== '') {
+		$allowed = array_filter(array_map('trim', explode(',', $allowlist)));
+		if ($origin !== '' && in_array($origin, $allowed, true)) {
+			header("Access-Control-Allow-Origin: {$origin}");
+			header('Vary: Origin');
+		}
+	}
+
+	header("Access-Control-Allow-Methods: OPTIONS,GET,POST,PUT,DELETE");
+	header("Access-Control-Max-Age: 3600");
+	header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+}
+
+dvwa_api_set_cors_headers();
+
 header("Content-Type: application/json; charset=UTF-8");
-header("Access-Control-Allow-Methods: OPTIONS,GET,POST,PUT,DELETE");
-header("Access-Control-Max-Age: 3600");
-header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
 header('Content-Type: application/x-yaml');
 echo $openapi->toYaml();

--- a/vulnerabilities/api/public/index.php
+++ b/vulnerabilities/api/public/index.php
@@ -8,11 +8,28 @@ use Src\OrderController;
 use Src\LoginController;
 use Src\Helpers;
 
-header("Access-Control-Allow-Origin: *");
-header("Content-Type: application/json; charset=UTF-8");
-header("Access-Control-Allow-Methods: OPTIONS,GET,POST,PUT,DELETE");
-header("Access-Control-Max-Age: 3600");
-header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+function dvwa_api_set_cors_headers(): void {
+	$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+	$allowlist = getenv('DVWA_API_CORS_ALLOW_ORIGINS');
+
+	// Default deny unless explicitly allowlisted.
+	if ($allowlist !== false && $allowlist !== '') {
+		$allowed = array_filter(array_map('trim', explode(',', $allowlist)));
+		if ($origin !== '' && in_array($origin, $allowed, true)) {
+			header("Access-Control-Allow-Origin: {$origin}");
+			header('Vary: Origin');
+		}
+	}
+
+	header("Content-Type: application/json; charset=UTF-8");
+	header("Access-Control-Allow-Methods: OPTIONS,GET,POST,PUT,DELETE");
+	header("Access-Control-Max-Age: 3600");
+	header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+}
+
+// CORS + common headers
+
+dvwa_api_set_cors_headers();
 
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 $uri = explode( '/', $uri );


### PR DESCRIPTION
Closes #43.

### What changed
- Replace `Access-Control-Allow-Origin: *` with an allowlist-based approach.
- Allowlist configured via `DVWA_API_CORS_ALLOW_ORIGINS` (comma-separated origins).
- Add `Vary: Origin` when reflecting an allowed origin.
- Default behavior is deny (no ACAO header).

### Security impact
Reduces risk of cross-origin data access/exfiltration from arbitrary websites.

### Compatibility
If you need browser access during development, set e.g.:
`DVWA_API_CORS_ALLOW_ORIGINS=http://localhost:4280`.

### Testing notes
- Manual review only (no runtime execution performed).