### PR TITLE
fix(security): safe env parsing, remove hardcoded creds, restrict phpinfo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and fill in real values
+# (Do NOT commit .env with secrets)
+
+# Database credentials (MariaDB)
+MYSQL_ROOT_PASSWORD=change_me_root_password
+
+# DVWA <-> DB connection
+DVWA_DB_SERVER=db
+DVWA_DB_DATABASE=dvwa
+DVWA_DB_USER=dvwa
+DVWA_DB_PASSWORD=change_me_app_password
+
+# Optional: explicitly disable authentication (intended for testing tools)
+# DISABLE_AUTHENTICATION=false

--- a/compose.yml
+++ b/compose.yml
@@ -13,7 +13,10 @@ services:
     # Change `always` to `build` to build from local source
     pull_policy: always
     environment:
-      - DB_SERVER=db
+      - DB_SERVER=${DVWA_DB_SERVER:-db}
+      - DB_DATABASE=${DVWA_DB_DATABASE:-dvwa}
+      - DB_USER=${DVWA_DB_USER:-dvwa}
+      - DB_PASSWORD=${DVWA_DB_PASSWORD}
     depends_on:
       - db
     # Uncomment the next 2 lines to serve local source
@@ -28,10 +31,10 @@ services:
   db:
     image: docker.io/library/mariadb:10
     environment:
-      - MYSQL_ROOT_PASSWORD=dvwa
-      - MYSQL_DATABASE=dvwa
-      - MYSQL_USER=dvwa
-      - MYSQL_PASSWORD=p@ssw0rd
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${DVWA_DB_DATABASE:-dvwa}
+      - MYSQL_USER=${DVWA_DB_USER:-dvwa}
+      - MYSQL_PASSWORD=${DVWA_DB_PASSWORD}
     volumes:
       - dvwa:/var/lib/mysql
     networks:

--- a/config/config.inc.php.dist
+++ b/config/config.inc.php.dist
@@ -18,7 +18,8 @@ $_DVWA = array();
 $_DVWA[ 'db_server' ]   = getenv('DB_SERVER') ?: '127.0.0.1';
 $_DVWA[ 'db_database' ] = getenv('DB_DATABASE') ?: 'dvwa';
 $_DVWA[ 'db_user' ]     = getenv('DB_USER') ?: 'dvwa';
-$_DVWA[ 'db_password' ] = getenv('DB_PASSWORD') ?: 'p@ssw0rd';
+# NOTE: For safer defaults, do not ship a real password in the repo.
+$_DVWA[ 'db_password' ] = getenv('DB_PASSWORD') ?: '';
 $_DVWA[ 'db_port']      = getenv('DB_PORT') ?: '3306';
 
 # ReCAPTCHA settings
@@ -40,7 +41,9 @@ $_DVWA[ 'default_locale' ] = getenv('DEFAULT_LOCALE') ?: 'en';
 # Disable authentication
 #   Some tools don't like working with authentication and passing cookies around
 #   so this setting lets you turn off authentication.
-$_DVWA[ 'disable_authentication' ] = getenv('DISABLE_AUTHENTICATION') ?: false;
+#
+# SECURITY: parse booleans safely (e.g., "false" should NOT disable auth)
+$_DVWA[ 'disable_authentication' ] = filter_var(getenv('DISABLE_AUTHENTICATION') ?: false, FILTER_VALIDATE_BOOLEAN);
 
 define ('MYSQL', 'mysql');
 define ('SQLITE', 'sqlite');

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -5,6 +5,12 @@ require_once DVWA_WEB_PAGE_TO_ROOT . 'dvwa/includes/dvwaPage.inc.php';
 
 dvwaPageStartup( array( 'authenticated') );
 
+// SECURITY: Restrict phpinfo() output to admins only.
+if (dvwaCurrentUser() !== 'admin') {
+	http_response_code(403);
+	die('Forbidden');
+}
+
 phpinfo();
 
 ?>


### PR DESCRIPTION
## Summary
This PR addresses multiple security issues identified during an automated + manual review.

## Fixes
1. **CWE-287 (Critical)**: Parse `DISABLE_AUTHENTICATION` as a real boolean (prevents accidental auth bypass when set to string values like `false`).
2. **CWE-798 (High)**: Remove hardcoded DB credentials from `compose.yml` and default config; introduce `.env.example`.
3. **CWE-200 (High)**: Restrict `phpinfo.php` output to `admin` only.

## Related Issues
- #47 (Critical auth bypass)
- #48 (Hardcoded DB creds)
- #46 (phpinfo exposure)

## Notes
DVWA is an intentionally vulnerable app for training. These changes are aimed at preventing accidental insecure-by-default deployments (especially in container environments).