### PR TITLE
Restrict phpinfo.php to admin users to reduce information disclosure

### DIFF
--- a/phpinfo.php
+++ b/phpinfo.php
@@ -3,7 +3,14 @@
 define( 'DVWA_WEB_PAGE_TO_ROOT', '' );
 require_once DVWA_WEB_PAGE_TO_ROOT . 'dvwa/includes/dvwaPage.inc.php';
 
-dvwaPageStartup( array( 'authenticated') );
+dvwaPageStartup( array( 'authenticated' ) );
+
+// phpinfo() leaks sensitive configuration details; restrict to admin user.
+if ( function_exists( 'dvwaCurrentUser' ) && dvwaCurrentUser() !== 'admin' ) {
+    header( 'HTTP/1.1 403 Forbidden' );
+    echo 'Forbidden';
+    exit;
+}
 
 phpinfo();
 


### PR DESCRIPTION
Fixes #51.

## What changed
- `phpinfo.php` now returns **403 Forbidden** for any authenticated user other than `admin`.

## Why
`phpinfo()` exposes sensitive runtime configuration details (extensions, paths, ini values, env vars) that can materially aid exploitation.

## Notes
DVWA is intentionally vulnerable for training; this PR reduces risk for accidental non-lab deployments while preserving the feature for admins.