### PR TITLE
Add optional DVWA_SAFE_MODE to reduce accidental SQLi exposure (SQLi low module)

### DIFF
--- a/config/config.inc.php.dist
+++ b/config/config.inc.php.dist
@@ -42,6 +42,11 @@ $_DVWA[ 'default_locale' ] = getenv('DEFAULT_LOCALE') ?: 'en';
 #   so this setting lets you turn off authentication.
 $_DVWA[ 'disable_authentication' ] = getenv('DISABLE_AUTHENTICATION') ?: false;
 
+# Safe mode
+#   Optional: when enabled, some modules can switch to safer implementations to reduce
+#   accidental exposure during demos. Example: DVWA_SAFE_MODE=true.
+$_DVWA[ 'safe_mode' ] = filter_var(getenv('DVWA_SAFE_MODE') ?: false, FILTER_VALIDATE_BOOLEAN);
+
 define ('MYSQL', 'mysql');
 define ('SQLITE', 'sqlite');
 

--- a/vulnerabilities/sqli/source/low.php
+++ b/vulnerabilities/sqli/source/low.php
@@ -3,12 +3,30 @@
 if( isset( $_REQUEST[ 'Submit' ] ) ) {
 	// Get input
 	$id = $_REQUEST[ 'id' ];
+	$id_display = $id;
+
+	// Optional safety switch for demos: set DVWA_SAFE_MODE=true to use parameterized queries.
+	// NOTE: DVWA is intentionally vulnerable by default; this flag helps prevent accidental exposure.
+	$safe_mode = ( isset($_DVWA['safe_mode']) && $_DVWA['safe_mode'] );
 
 	switch ($_DVWA['SQLI_DB']) {
 		case MYSQL:
 			// Check database
-			$query  = "SELECT first_name, last_name FROM users WHERE user_id = '$id';";
-			$result = mysqli_query($GLOBALS["___mysqli_ston"],  $query ) or die( '<pre>' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '</pre>' );
+			if( $safe_mode ) {
+				$id_int = (int) $id;
+				$id_display = $id_int;
+
+				$stmt = mysqli_prepare($GLOBALS["___mysqli_ston"], "SELECT first_name, last_name FROM users WHERE user_id = ?;");
+				if( $stmt === false ) {
+					die( '<pre>' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '</pre>' );
+				}
+				mysqli_stmt_bind_param($stmt, "i", $id_int);
+				mysqli_stmt_execute($stmt);
+				$result = mysqli_stmt_get_result($stmt);
+			} else {
+				$query  = "SELECT first_name, last_name FROM users WHERE user_id = '$id';";
+				$result = mysqli_query($GLOBALS["___mysqli_ston"],  $query ) or die( '<pre>' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '</pre>' );
+			}
 
 			// Get results
 			while( $row = mysqli_fetch_assoc( $result ) ) {
@@ -17,9 +35,12 @@ if( isset( $_REQUEST[ 'Submit' ] ) ) {
 				$last  = $row["last_name"];
 
 				// Feedback for end user
-				$html .= "<pre>ID: {$id}<br />First name: {$first}<br />Surname: {$last}</pre>";
+				$html .= "<pre>ID: {$id_display}<br />First name: {$first}<br />Surname: {$last}</pre>";
 			}
 
+			if( $safe_mode && isset($stmt) ) {
+				mysqli_stmt_close($stmt);
+			}
 			mysqli_close($GLOBALS["___mysqli_ston"]);
 			break;
 		case SQLITE:
@@ -28,13 +49,27 @@ if( isset( $_REQUEST[ 'Submit' ] ) ) {
 			#$sqlite_db_connection = new SQLite3($_DVWA['SQLITE_DB']);
 			#$sqlite_db_connection->enableExceptions(true);
 
-			$query  = "SELECT first_name, last_name FROM users WHERE user_id = '$id';";
-			#print $query;
-			try {
-				$results = $sqlite_db_connection->query($query);
-			} catch (Exception $e) {
-				echo 'Caught exception: ' . $e->getMessage();
-				exit();
+			if( $safe_mode ) {
+				$id_int = (int) $id;
+				$id_display = $id_int;
+
+				$stmt = $sqlite_db_connection->prepare("SELECT first_name, last_name FROM users WHERE user_id = :id;");
+				$stmt->bindValue(':id', $id_int, SQLITE3_INTEGER);
+				try {
+					$results = $stmt->execute();
+				} catch (Exception $e) {
+					echo 'Caught exception: ' . $e->getMessage();
+					exit();
+				}
+			} else {
+				$query  = "SELECT first_name, last_name FROM users WHERE user_id = '$id';";
+				#print $query;
+				try {
+					$results = $sqlite_db_connection->query($query);
+				} catch (Exception $e) {
+					echo 'Caught exception: ' . $e->getMessage();
+					exit();
+				}
 			}
 
 			if ($results) {
@@ -44,13 +79,13 @@ if( isset( $_REQUEST[ 'Submit' ] ) ) {
 					$last  = $row["last_name"];
 
 					// Feedback for end user
-					$html .= "<pre>ID: {$id}<br />First name: {$first}<br />Surname: {$last}</pre>";
+					$html .= "<pre>ID: {$id_display}<br />First name: {$first}<br />Surname: {$last}</pre>";
 				}
 			} else {
 				echo "Error in fetch ".$sqlite_db->lastErrorMsg();
 			}
 			break;
-	} 
+	}
 }
 
 ?>


### PR DESCRIPTION
### What
Adds an **optional** `DVWA_SAFE_MODE` flag (off by default) to allow safer execution of the SQLi *low* module query using prepared statements.

### Why
DVWA is intentionally vulnerable, but it is often deployed for demos/training and accidentally exposed. This PR keeps default behavior unchanged while offering a guardrail.

### Changes
- `config/config.inc.php.dist`: adds `$_DVWA['safe_mode']` from `DVWA_SAFE_MODE` env var.
- `vulnerabilities/sqli/source/low.php`: when `$_DVWA['safe_mode']` is true, uses prepared statements (mysqli/SQLite) and casts `id` to int.

### Security notes
- Default remains vulnerable.
- Enabling safe mode mitigates CWE-89 in this specific module.

Fixes/relates-to:
- #55
