### PR TITLE
Security hardening: gate phpinfo endpoint and disable allow_url_include by default

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -2,4 +2,5 @@
 
 magic_quotes_gpc = Off
 allow_url_fopen = on
-allow_url_include = on
+; SECURITY: allow_url_include enables remote file inclusion and should be off by default.
+allow_url_include = off

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -1,9 +1,21 @@
 <?php
 
+/**
+ * Security hardening: phpinfo() leaks sensitive environment/configuration.
+ * Gate this endpoint behind an explicit opt-in environment variable.
+ */
+
 define( 'DVWA_WEB_PAGE_TO_ROOT', '' );
 require_once DVWA_WEB_PAGE_TO_ROOT . 'dvwa/includes/dvwaPage.inc.php';
 
 dvwaPageStartup( array( 'authenticated') );
+
+// Default: disabled
+$enabled = getenv('DVWA_ENABLE_PHPINFO') ?: '';
+if ($enabled !== '1') {
+    header('HTTP/1.1 404 Not Found');
+    exit;
+}
 
 phpinfo();
 


### PR DESCRIPTION
## Summary
This PR hardens DVWA defaults to reduce accidental exposure when deployed outside an isolated lab environment.

## Changes
- `phpinfo.php`: gate `phpinfo()` behind `DVWA_ENABLE_PHPINFO=1` (otherwise 404)
- `php.ini`: set `allow_url_include = off` by default

## Why
- `phpinfo()` can disclose sensitive configuration/environment details that materially aid exploitation.
- `allow_url_include=On` enables Remote File Inclusion when paired with unsafe `include()` usage.

## Notes
This does not attempt to remove DVWA’s intentionally vulnerable modules; it only changes insecure defaults and restricts a high-impact diagnostic endpoint.

Fixes #61 (partial hardening), addresses #62 (mitigation by disabling allow_url_include), and helps reduce impact of file inclusion vectors.
