### PR TITLE
security: remove hardcoded DB credentials from compose/config template

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,10 +1,8 @@
 volumes:
   dvwa:
 
-
 networks:
   dvwa:
-
 
 services:
   dvwa:
@@ -28,10 +26,12 @@ services:
   db:
     image: docker.io/library/mariadb:10
     environment:
-      - MYSQL_ROOT_PASSWORD=dvwa
-      - MYSQL_DATABASE=dvwa
-      - MYSQL_USER=dvwa
-      - MYSQL_PASSWORD=p@ssw0rd
+      # Do NOT hardcode secrets in source. Set these in a local .env file,
+      # CI secrets, or Docker secrets.
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:?set in .env}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-dvwa}
+      - MYSQL_USER=${MYSQL_USER:-dvwa}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:?set in .env}
     volumes:
       - dvwa:/var/lib/mysql
     networks:

--- a/config/config.inc.php.dist
+++ b/config/config.inc.php.dist
@@ -18,7 +18,13 @@ $_DVWA = array();
 $_DVWA[ 'db_server' ]   = getenv('DB_SERVER') ?: '127.0.0.1';
 $_DVWA[ 'db_database' ] = getenv('DB_DATABASE') ?: 'dvwa';
 $_DVWA[ 'db_user' ]     = getenv('DB_USER') ?: 'dvwa';
-$_DVWA[ 'db_password' ] = getenv('DB_PASSWORD') ?: 'p@ssw0rd';
+
+# Do not ship insecure default passwords. Require explicit configuration.
+$_DVWA[ 'db_password' ] = getenv('DB_PASSWORD');
+if ($_DVWA['db_password'] === false || $_DVWA['db_password'] === '') {
+    die('DVWA System error - DB_PASSWORD must be set in the environment.');
+}
+
 $_DVWA[ 'db_port']      = getenv('DB_PORT') ?: '3306';
 
 # ReCAPTCHA settings


### PR DESCRIPTION
## What
Removes hardcoded database credentials from:
- `compose.yml` (MariaDB env vars)
- `config/config.inc.php.dist` (no default DB_PASSWORD)

## Why
Hardcoded/known credentials are frequently copy-pasted into non-training deployments and can lead to immediate compromise of the database.

Closes:
- #64
- #65

## Notes
This change is intended for safer-by-default deployments. For local training, set credentials via a local `.env` file (not committed) or CI secrets.
